### PR TITLE
Solving issue #13 (related fields access)

### DIFF
--- a/secretballot/__init__.py
+++ b/secretballot/__init__.py
@@ -73,6 +73,7 @@ def enable_voting_on(cls, manager_name='objects',
                                            'be installed. (see secretballot/middleware.py)')
             return self.from_token(request.secretballot_token)
 
+    cls.add_to_class('_default_manager', VotableManager())
     cls.add_to_class(manager_name, VotableManager())
     cls.add_to_class(votes_name, generic.GenericRelation(Vote))
     cls.add_to_class(total_name, property(get_total))


### PR DESCRIPTION
This pull request solves the problem raised in issue #13.

The problem was that accessing an object using

``` python
post = get_object_or_404(Post, pk=post_id)
```

or

``` python
post_moderator.post
```

didn't use the VotableManager but the "plain" manager django.db.models.Manager as explained [here](https://docs.djangoproject.com/en/dev/topics/db/managers/#using-managers-for-related-object-access).

Adding

``` python
use_for_related_fields = True
```

to the VotableManager class solves this problem, as explained [here](https://docs.djangoproject.com/en/dev/topics/db/managers/#manager-types).
