### PR TITLE
Fix/token encoding issues

### DIFF
--- a/secretballot/__init__.py
+++ b/secretballot/__init__.py
@@ -76,7 +76,7 @@ def enable_voting_on(cls, manager_name='objects',
                                            'be installed. (see secretballot/middleware.py)')
             return self.from_token(request.secretballot_token)
 
-    if django.VERSION < (1,10):
+    if django.VERSION < (1, 10):
         cls.add_to_class('_default_manager', VotableManager())
         cls.add_to_class(manager_name, VotableManager())
     else:

--- a/secretballot/middleware.py
+++ b/secretballot/middleware.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from hashlib import md5
 
 
@@ -16,5 +17,5 @@ class SecretBallotIpMiddleware(SecretBallotMiddleware):
 
 class SecretBallotIpUseragentMiddleware(SecretBallotMiddleware):
     def generate_token(self, request):
-        s = ''.join((request.META['REMOTE_ADDR'], request.META.get('HTTP_USER_AGENT', '')))
-        return md5(s.encode('utf8')).hexdigest()
+        s = u"".join((request.META['REMOTE_ADDR'], request.META.get('HTTP_USER_AGENT', '')))
+        return md5(s.encode('utf-8')).hexdigest()

--- a/secretballot/views.py
+++ b/secretballot/views.py
@@ -1,4 +1,4 @@
-from django.template import loader, RequestContext
+from django.template import loader
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpResponseForbidden
 from django.db.models.base import ModelBase

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 from django.test import TestCase, Client
 from django.http import HttpRequest, Http404, HttpResponseForbidden
@@ -60,6 +61,16 @@ class MiddlewareTestCase(TestCase):
         mw = SecretBallotMiddleware()
         with self.assertRaises(NotImplementedError):
             mw.process_request(HttpRequest())
+
+    def test_unicode_token(self):
+        mw = SecretBallotIpUseragentMiddleware()
+        r = HttpRequest()
+        r.META['REMOTE_ADDR'] = '1.2.3.4'
+        r.META['HTTP_USER_AGENT'] = u"Orange España"
+        mw.process_request(r)
+        token = r.secretballot_token
+
+        assert token == 'fdb9f3e35ac8355e1e97f338f0ede097'
 
 
 class TestVoting(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py35-django111, py27-django111, py35-django110, py27-django110, py27-d
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 --ignore=E402,E731 secretballot
+commands = flake8 --ignore=E402,E731,E501 secretballot
 
 
 [django18]


### PR DESCRIPTION
This should fix issue #38.

Also added changes for the `flake8` build:
- Added rule E501 to be ignored.
- Removed unused import `RequestContext`.
- Added space after comma to comply with PEP rules. 