### PR TITLE
Do not set VotableManager as the default manager

### DIFF
--- a/secretballot/__init__.py
+++ b/secretballot/__init__.py
@@ -87,7 +87,6 @@ def enable_voting_on(cls, manager_name='objects',
             manager for manager in cls._meta.local_managers if not manager.name == manager_name
         )
         cls.add_to_class(manager_name, vm)
-        cls._meta.default_manager_name = manager_name
     cls.add_to_class(votes_name, GenericRelation(Vote))
     cls.add_to_class(total_name, property(get_total))
     cls.add_to_class(add_vote_name, add_vote)


### PR DESCRIPTION
Hi @jamesturk. Can you also have a look at this one please?
Setting the `VotableManager` as the default here causes some undesirable effects in the models that use it. More info on this can be found [in the docs](https://docs.djangoproject.com/en/1.11/topics/db/managers/#default-managers)

If you're happy with this, can you also prepare a release?