### PR TITLE
make sure db access is only evaluated when needed

### DIFF
--- a/secretballot/tests/models.py
+++ b/secretballot/tests/models.py
@@ -21,3 +21,7 @@ class WeirdLink(models.Model):
 # Used for testing custom manager_name
 class AnotherLink(models.Model):
     url = models.URLField()
+
+# Used for testing custom manager_name
+class NonAutomaticEnabledModel(models.Model):
+    url = models.URLField()


### PR DESCRIPTION
This fixes the issue reported in #51 

The problem was that `VotableManager.get_queryset` uses `ContentType.objects.get_for_model` and this performs an actual db query.
When you use a `ModelForm` for your votable model then the `get_queryset` method of your manager gets called.
As such if you write a test for a `ModelForm` then when you just collect those tests the db gets accessed which might not even exist at that point.

This is solved in this PR by using `Subquery` and `Count` without the need for actually touching the `ContentType` related table ourselves.


